### PR TITLE
Resolve streched image issue on SLEFLogo

### DIFF
--- a/app/src/scenes/Home/index.tsx
+++ b/app/src/scenes/Home/index.tsx
@@ -28,11 +28,11 @@ class Home extends React.Component {
                   AcadeMiX is built in collaboration with,
                 </Title>
               </Row>
-              <Col md={6} lg={3}>
-                <Row>
+              <Row>
+                <Col md={6} lg={3}>
                   <img src={SLEFLogo} alt="SLEF Logo" width={220} />
-                </Row>
-              </Col>
+                </Col>
+              </Row>
             </Col>
             <Col md={1} />
             <Col md={13}>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #27 

## Goals
To resolve the stretched image issue on SLEF logo on the hero section

## Approach
- Fixed the miss used `Col` `Row` pattern wrapping the image

## Screenshot
![image](https://user-images.githubusercontent.com/45477334/85259965-8f8a1f80-b487-11ea-8e33-2b41da6444bc.png)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Browser: Safari, Google chrome
Server: Tomcat 9
Os: macOS Catalina 10.15.3

