### PR TITLE
Load first subcategory as the default

### DIFF
--- a/app/src/scenes/SubCategories/index.tsx
+++ b/app/src/scenes/SubCategories/index.tsx
@@ -4,8 +4,14 @@ import axios, { AxiosResponse } from 'axios';
 import { handleApiError } from '../../services/util/errorHandler';
 import { SubCategoryStateProps, CategoryUrlParams } from './interfaces';
 import { RouteComponentProps } from 'react-router';
-import { Menu, Typography } from 'antd';
-import { Link, Route, BrowserRouter as Router, Switch } from 'react-router-dom';
+import { Col, Menu, PageHeader, Row, Typography } from 'antd';
+import {
+  Link,
+  Route,
+  BrowserRouter as Router,
+  withRouter,
+  Redirect,
+} from 'react-router-dom';
 import { Category, SubCategory } from '../../interfaces';
 import Items from './scenes/Items';
 
@@ -80,6 +86,16 @@ class SubCategories extends React.Component<
     });
   };
 
+  setCurrent = (subCategoryId: string) => {
+    this.setState({
+      current: subCategoryId,
+    });
+  };
+
+  onBack = () => {
+    this.props.history.push('/academix');
+  };
+
   render() {
     const { Title } = Typography;
     let title = '';
@@ -88,40 +104,62 @@ class SubCategories extends React.Component<
     }
     return (
       <Router>
-        <Title level={2} className={styles.mainContent}>
-          {title}
-        </Title>
-        <Menu
-          mode="horizontal"
-          onClick={this.handleClick}
-          selectedKeys={[this.state.current]}
-        >
-          {this.state.subCategories.map((subCategory) => {
-            // Replace spaces and slashes from the subcategory name to include it on the URL
-            const categoryName = title
-              .trim()
-              .replace(/\s+|\//g, '-')
-              .toLowerCase();
-            return (
-              <Menu.Item key={subCategory.id} className={styles.menuItem}>
-                <Link
-                  to={`/academix/${this.CategoryId}/${categoryName}/${subCategory.id}`}
-                >
-                  {subCategory.translations[0].name}
-                </Link>
-              </Menu.Item>
-            );
-          })}
-        </Menu>
-        <Switch>
-          <Route
-            path="/academix/:categoryId/:categoryName/:subCategoryId"
-            component={Items}
-          />
-        </Switch>
+        <Row className={styles.mainContent}>
+          <Col md={20}>
+            <PageHeader
+              className={styles.pageHeader}
+              onBack={this.onBack}
+              title={
+                <Title className={styles.pageTitle} level={2}>
+                  {title}
+                </Title>
+              }
+            />
+          </Col>
+        </Row>
+        <Row className={styles.mainContent}>
+          <Col md={20}>
+            <Menu
+              mode="horizontal"
+              onClick={this.handleClick}
+              selectedKeys={[this.state.current]}
+            >
+              {this.state.subCategories.map((subCategory) => {
+                // Replace spaces and slashes from the subcategory name to include it on the URL
+                const categoryName = title
+                  .trim()
+                  .replace(/\s+|\//g, '-')
+                  .toLowerCase();
+                return (
+                  <Menu.Item key={subCategory.id} className={styles.menuItem}>
+                    <Link
+                      to={`/academix/${this.CategoryId}/${categoryName}/${subCategory.id}`}
+                    >
+                      {subCategory.translations[0].name}
+                    </Link>
+                  </Menu.Item>
+                );
+              })}
+            </Menu>
+          </Col>
+        </Row>
+        <Row className={styles.mainContent}>
+          <Col md={20}>
+            <Route path="/academix/:categoryId/:categoryName/:subCategoryId">
+              <Items setCurrent={this.setCurrent} />
+            </Route>
+            //Todo: Use history.push to redirect to the first subcategory
+            {this.state.subCategories.length > 0 && (
+              <Redirect
+                exact
+                to={`${this.props.match.url}/${this.state.subCategories[0].id}`}
+              />
+            )}
+          </Col>
+        </Row>
       </Router>
     );
   }
 }
 
-export default SubCategories;
+export default withRouter(SubCategories);

--- a/app/src/scenes/SubCategories/scenes/Items/index.tsx
+++ b/app/src/scenes/SubCategories/scenes/Items/index.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
 import axios, { AxiosResponse } from 'axios';
 import { handleApiError } from '../../../../services/util/errorHandler';
-import { Item, ItemPayload, ItemStateProps, ItemUrlParams } from './interfaces';
+import {
+  Item,
+  ItemPayload,
+  ItemProps,
+  ItemStateProps,
+  ItemUrlParams,
+} from './interfaces';
 import { List, Button, Modal } from 'antd';
-import { RouteComponentProps } from 'react-router';
+import { RouteComponentProps, withRouter } from 'react-router';
 import styles from './styles.module.css';
 
 class Items extends React.Component<
-  RouteComponentProps<ItemUrlParams>,
+  RouteComponentProps<ItemUrlParams> & ItemProps,
   ItemStateProps
 > {
   pageSize: number;
   SubCategoryId: string;
-  constructor(props: RouteComponentProps<ItemUrlParams>) {
+  constructor(props: RouteComponentProps<ItemUrlParams> & ItemProps) {
     super(props);
     this.pageSize = 10;
     this.SubCategoryId = this.props.match.params.subCategoryId;
+    this.props.setCurrent(this.SubCategoryId);
     this.state = {
       isLoading: false,
       isModalVisible: false,
@@ -105,7 +112,6 @@ class Items extends React.Component<
           </Modal>
         )}
         <List
-          className={styles.mainContent}
           pagination={{
             onChange: this.fetchItems,
             pageSize: this.pageSize,
@@ -132,4 +138,4 @@ class Items extends React.Component<
   }
 }
 
-export default Items;
+export default withRouter(Items);

--- a/app/src/scenes/SubCategories/scenes/Items/interfaces.ts
+++ b/app/src/scenes/SubCategories/scenes/Items/interfaces.ts
@@ -30,3 +30,7 @@ export interface ItemPayload {
 export interface ItemUrlParams {
   subCategoryId: string;
 }
+
+export interface ItemProps {
+  setCurrent: (subCategoryId: string) => void;
+}

--- a/app/src/scenes/SubCategories/styles.module.css
+++ b/app/src/scenes/SubCategories/styles.module.css
@@ -1,11 +1,21 @@
 .mainContent {
-    padding-left: 40px;
+    padding-left: 10px;
     padding-top: 20px;
+    justify-content: center;
 }
 
 .menuItem{
     text-align: center;
     margin-left: 30px;
     margin-right: 30px;
-    font-size: 20px;
+    font-size: 15px;
+}
+
+.pageTitle{
+    margin-top: 14px;
+}
+
+.pageHeader :global .anticon{
+    font-size: 25px;
+    vertical-align: middle;
 }


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #35 

## Goals
To Load the first subcategory of the particular category when clicked

## Approach
- Redirected to the first subcategory link when sub category page is loaded
- Added a back button to return to the academix home page
- Fixed alignment issues

## Screenshots
![image](https://user-images.githubusercontent.com/45477334/85918839-c72c0980-b883-11ea-9b92-5bc44d09805c.png)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
N/R

## Test environment
- Browser: Google chrome
- TestServer: Tomcat 9
- JavaVersion: OpenJDK 11
- Os: macOS 10.15.3

## Learning
* [AntD docs](https://ant.design/components/page-header/)
